### PR TITLE
Remove unused global sanitizeHTML comment from content-script.js

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -1,4 +1,3 @@
-/* global sanitizeHTML */
 // Canvas-Notion Sync: API-Only Assignment Extractor
 
 // Prevent multiple initialization


### PR DESCRIPTION
## Summary
Removed an unused global variable declaration comment from the content script.

## Changes
- Removed the `/* global sanitizeHTML */` comment from the top of content-script.js

## Details
The `sanitizeHTML` global variable declaration was not being used in the script and has been removed to clean up the code and reduce unnecessary comments.

https://claude.ai/code/session_01YVKjcaSLwvHCqdWsZAiH3r