### PR TITLE
Remove fallback submission API call in assignment extraction

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -158,7 +158,7 @@ class CanvasAPIExtractor {
             let gradePercent = null;
             let submissionStatus = 'Not Started';
 
-            // Get submission data if available
+            // Get submission data if available (included via ?include=submission)
             if (assignment.submission) {
               const submission = assignment.submission;
               if (submission.grade) {
@@ -168,20 +168,6 @@ class CanvasAPIExtractor {
                 gradePercent = Math.round((submission.score / assignment.points_possible) * 100);
               }
               submissionStatus = this.getSubmissionStatus(submission);
-            } else {
-              // Try to get submission separately if not included
-              try {
-                const submission = await this.makeAPICall(`/courses/${course.id}/assignments/${assignment.id}/submissions/self`);
-                if (submission.grade) {
-                  grade = submission.grade;
-                }
-                if (submission.score && assignment.points_possible) {
-                  gradePercent = Math.round((submission.score / assignment.points_possible) * 100);
-                }
-                submissionStatus = this.getSubmissionStatus(submission);
-              } catch (error) {
-                // Submission not available - will use default status
-              }
             }
 
             transformedAssignments.push({


### PR DESCRIPTION
## Summary
Removed the fallback logic that attempted to fetch submission data via a separate API call when submission data wasn't included in the initial assignment response. The code now relies solely on submission data included via the `?include=submission` query parameter.

## Key Changes
- Removed the `else` block that made an additional API call to `/courses/{id}/assignments/{id}/submissions/self` when submission data wasn't available in the assignment object
- Removed associated error handling for the fallback submission fetch
- Updated the comment to clarify that submission data must be included via the `?include=submission` parameter

## Implementation Details
This change simplifies the submission data retrieval logic by eliminating an extra API call per assignment. The code now assumes that if submission data is needed, it will be included in the initial assignment query. This reduces API overhead and makes the data flow more explicit and predictable.

https://claude.ai/code/session_01RJwv9DTBZDRQQJFmvhWHGu