### PR TITLE
test: add Notion rate-limiter integration coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,19 @@ jobs:
         with:
           name: coverage-report
           path: coverage/
+
+  test-rate-limiter:
+    name: Rate Limiter Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Run Notion rate limiter integration tests
+        run: npm run test:integration-rate

--- a/TODO.md
+++ b/TODO.md
@@ -385,10 +385,10 @@
   - [x] Remove entirely from `notion-api.js` constructor and all methods
   - [x] Remove `bypassRateLimit: true` from `background-handlers.js`
   - [x] All API methods now always use rate limiter + executeWithRetry
-- [ ] Test with adjusted limits
-  - [ ] Verify 3 req/sec average is enforced
-  - [ ] Verify burst handling still works
-  - [ ] Test with large sync operations
+- [x] Test with adjusted limits
+  - [x] Verify 3 req/sec average is enforced
+  - [x] Verify burst handling still works
+  - [x] Test with large sync operations
 - [x] Update comments in code
 
 ---

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@ export default {
   transform: {},
   testEnvironment: 'node',
   setupFiles: ['./test/setup.js'],
+  testPathIgnorePatterns: ['\\\\node_modules\\\\', 'notion-rate-limiter\\.integration\\.test\\.js$'],
   collectCoverageFrom: ['src/**/*.js'],
   coverageThreshold: {
     global: { branches: 60, functions: 70, lines: 70, statements: 70 }

--- a/jest.integration-rate.config.js
+++ b/jest.integration-rate.config.js
@@ -1,0 +1,7 @@
+import baseConfig from './jest.config.js';
+
+export default {
+  ...baseConfig,
+  testPathIgnorePatterns: ['\\\\node_modules\\\\'],
+  collectCoverage: false
+};

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage",
+    "test:integration-rate": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.integration-rate.config.js --runTestsByPath test/integration/notion-rate-limiter.integration.test.js --runInBand",
     "lint": "eslint . --ext .js --config .eslintrc.security.json --ignore-pattern '.github/'",
     "check:security": "node .github/scripts/check-credentials.cjs && node .github/scripts/check-dangerous-functions.cjs && node .github/scripts/check-https.cjs && node .github/scripts/check-permissions.cjs && node .github/scripts/check-csp.cjs"
   },

--- a/test/integration/notion-rate-limiter.integration.test.js
+++ b/test/integration/notion-rate-limiter.integration.test.js
@@ -1,0 +1,73 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { NotionRateLimiter } from '../../src/api/notion-rate-limiter.js';
+
+jest.setTimeout(120000);
+
+async function runQueuedRequests(limiter, requestCount) {
+  const startTimes = [];
+
+  const requests = Array.from({ length: requestCount }, (_, index) =>
+    limiter.execute(async () => {
+      startTimes.push(Date.now());
+      return index;
+    })
+  );
+
+  await Promise.all(requests);
+  startTimes.sort((a, b) => a - b);
+  return startTimes;
+}
+
+function maxRequestsInWindow(timestamps, windowMs) {
+  let maxCount = 0;
+  let left = 0;
+
+  for (let right = 0; right < timestamps.length; right++) {
+    while (timestamps[right] - timestamps[left] >= windowMs) {
+      left++;
+    }
+    const windowCount = right - left + 1;
+    if (windowCount > maxCount) {
+      maxCount = windowCount;
+    }
+  }
+
+  return maxCount;
+}
+
+describe('NotionRateLimiter integration (timing-based)', () => {
+  test('uses the adjusted Notion rate-limit settings', () => {
+    const limiter = new NotionRateLimiter();
+    expect(limiter.maxRequestsPerSecond).toBe(5);
+    expect(limiter.averageRequestsPerSecond).toBe(3);
+    expect(limiter.averageWindow).toBe(10000);
+  });
+
+  test('enforces burst handling (max 5 request starts per second)', async () => {
+    const limiter = new NotionRateLimiter();
+    const starts = await runQueuedRequests(limiter, 10);
+
+    expect(starts).toHaveLength(10);
+    const firstSecondCount = starts.filter((time) => time - starts[0] < 1000).length;
+    expect(firstSecondCount).toBe(5);
+    expect(starts[5] - starts[0]).toBeGreaterThanOrEqual(900);
+  });
+
+  test('enforces sustained average limit (max 30 request starts per 10 seconds)', async () => {
+    const limiter = new NotionRateLimiter();
+    const starts = await runQueuedRequests(limiter, 40);
+
+    expect(starts).toHaveLength(40);
+    expect(maxRequestsInWindow(starts, 10000)).toBeLessThanOrEqual(30);
+    expect(starts[39] - starts[0]).toBeGreaterThanOrEqual(10000);
+  });
+
+  test('holds rate limits during a large sync-sized workload (100 operations)', async () => {
+    const limiter = new NotionRateLimiter();
+    const starts = await runQueuedRequests(limiter, 100);
+
+    expect(starts).toHaveLength(100);
+    expect(maxRequestsInWindow(starts, 1000)).toBeLessThanOrEqual(5);
+    expect(maxRequestsInWindow(starts, 10000)).toBeLessThanOrEqual(30);
+  });
+});


### PR DESCRIPTION
## Summary
- add timing-based Notion rate-limiter integration tests
- add dedicated jest config and npm script for the slow suite
- run rate-limiter integration tests in a separate CI job
- keep default npm test suite fast by excluding this file

## Validation
- npm run test:integration-rate
- npm test